### PR TITLE
Schema changes to add a layer for template variables

### DIFF
--- a/daint.cscs.ch/gpu/codes/QE-7.2-exe-template.yml
+++ b/daint.cscs.ch/gpu/codes/QE-7.2-exe-template.yml
@@ -8,11 +8,12 @@ prepend_text: |
     module load QuantumESPRESSO
 append_text: ' '
 metadata:
-    code_binary_name:
-        type: list
-        key_display: Code name
-        options:
-            - pw
-            - ph
-            - dos
-            - projwfc
+    template_variables:
+        code_binary_name:
+            type: list
+            key_display: Code name
+            options:
+                - pw
+                - ph
+                - dos
+                - projwfc

--- a/daint.cscs.ch/gpu/computer-configure.yml
+++ b/daint.cscs.ch/gpu/computer-configure.yml
@@ -8,7 +8,8 @@ metadata:
             Setup up the SSH connection.
         </p>
     ssh_auth: 2FA
-    username:
-        description: The username to use for the SSH connection
-        type: text
-        key_display: SSH username
+    template_variables:
+        username:
+            description: The username to use for the SSH connection
+            type: text
+            key_display: SSH username

--- a/daint.cscs.ch/gpu/computer-setup.yml
+++ b/daint.cscs.ch/gpu/computer-setup.yml
@@ -28,33 +28,34 @@ metadata:
             The CSCS now require MFA to login, please check the <a href="https://user.cscs.ch/access/auth/mfa/" target="_blank">MFA CSCS documentation</a> for details on how to set up SSH connection. <br>
             If you are using the AiiDAlab, please use the <a href="https://github.com/aiidalab/aiidalab-mfa-cscs" target="_blank">MFA CSCS plugin</a> to set SSH connection.
         </p>
-    label:
-        default: daint-gpu
-        description: A short name to identify the computer
-        type: text
-        key_display: Computer Label
-    slurm_partition:
-        default: normal
-        description: The slurm partition to submit jobs to
-        type: list
-        options:
-            - normal
-            - debug
-            - large
-            - long
-            - low
-            - prepost
-        key_display: Slurm partition
-    slurm_account:
-        description: The slurm account to submit jobs to
-        type: text
-        key_display: Slurm account
-    multithreading:
-        default: nomultithread
-        description: The multithreading hint
-        type: list
-        options:
-            - nomultithread
-            - multithread
-        key_display: Multithreading hint
+    template_variables:
+        label:
+            default: daint-gpu
+            description: A short name to identify the computer
+            type: text
+            key_display: Computer Label
+        slurm_partition:
+            default: normal
+            description: The slurm partition to submit jobs to
+            type: list
+            options:
+                - normal
+                - debug
+                - large
+                - long
+                - low
+                - prepost
+            key_display: Slurm partition
+        slurm_account:
+            description: The slurm account to submit jobs to
+            type: text
+            key_display: Slurm account
+        multithreading:
+            default: nomultithread
+            description: The multithreading hint
+            type: list
+            options:
+                - nomultithread
+                - multithread
+            key_display: Multithreading hint
 

--- a/daint.cscs.ch/mc/codes/QE-7.0-exe-template.yml
+++ b/daint.cscs.ch/mc/codes/QE-7.0-exe-template.yml
@@ -8,11 +8,12 @@ prepend_text: |
     module load QuantumESPRESSO
 append_text: ''
 metadata:
-    code_binary_name:
-        key_display: Code name
-        type: list
-        options:
-            - pw
-            - ph
-            - dos
-            - projwfc
+    templte_variables:
+        code_binary_name:
+            key_display: Code name
+            type: list
+            options:
+                - pw
+                - ph
+                - dos
+                - projwfc

--- a/daint.cscs.ch/mc/codes/QE-7.2-exe-template.yml
+++ b/daint.cscs.ch/mc/codes/QE-7.2-exe-template.yml
@@ -8,11 +8,12 @@ prepend_text: |
     module load QuantumESPRESSO
 append_text: ''
 metadata:
-    code_binary_name:
-        key_display: Code name
-        type: list
-        options:
-            - pw
-            - ph
-            - dos
-            - projwfc
+    templte_variables:
+        code_binary_name:
+            key_display: Code name
+            type: list
+            options:
+                - pw
+                - ph
+                - dos
+                - projwfc

--- a/daint.cscs.ch/mc/computer-configure.yml
+++ b/daint.cscs.ch/mc/computer-configure.yml
@@ -8,7 +8,8 @@ metadata:
             Setup up the SSH connection.
         </p>
     ssh_auth: 2FA
-    username:
-        description: The username to use for the SSH connection
-        type: text
-        key_display: SSH username
+    template_variables:
+        username:
+            description: The username to use for the SSH connection
+            type: text
+            key_display: SSH username

--- a/daint.cscs.ch/mc/computer-setup.yml
+++ b/daint.cscs.ch/mc/computer-setup.yml
@@ -25,32 +25,33 @@ metadata:
             The CSCS now require MFA to login, please check the <a href="https://user.cscs.ch/access/auth/mfa/" target="_blank">MFA CSCS documentation</a> for details on how to set up SSH connection. <br>
             If you are using the AiiDAlab, please use the <a href="https://github.com/aiidalab/aiidalab-mfa-cscs" target="_blank">MFA CSCS plugin</a> to set SSH connection.
         </p>
-    label:
-        default: daint-mc
-        description: A short name to identify the computer
-        type: text
-        key_display: Computer Label
-    slurm_partition:
-        default: normal
-        description: The slurm partition to submit jobs to
-        type: list
-        options:
-            - normal
-            - debug
-            - large
-            - long
-            - low
-            - prepost
-        key_display: Slurm partition
-    slurm_account:
-        description: The slurm account to submit jobs to
-        type: text
-        key_display: Slurm account
-    multithreading:
-        default: nomultithread
-        description: The multithreading hint
-        type: list
-        options:
-            - nomultithread
-            - multithread
-        key_display: Multithreading hint
+    template_variables:
+        label:
+            default: daint-mc
+            description: A short name to identify the computer
+            type: text
+            key_display: Computer Label
+        slurm_partition:
+            default: normal
+            description: The slurm partition to submit jobs to
+            type: list
+            options:
+                - normal
+                - debug
+                - large
+                - long
+                - low
+                - prepost
+            key_display: Slurm partition
+        slurm_account:
+            description: The slurm account to submit jobs to
+            type: text
+            key_display: Slurm account
+        multithreading:
+            default: nomultithread
+            description: The multithreading hint
+            type: list
+            options:
+                - nomultithread
+                - multithread
+            key_display: Multithreading hint

--- a/gh_page/resource.schema.json
+++ b/gh_page/resource.schema.json
@@ -14,17 +14,8 @@
             "$ref": "#/definitions/resource"
         }
     },
-    "metadata": {
+    "template_variables": {
         "type": "object",
-        "properties": {
-            "tooltip": {
-                "type": "string"
-            },
-            "ssh_auth": {
-                "type": "string",
-                "enum": ["password", "2FA"]
-            }
-        },
         "additionalProperties": {
             "type": "object",
             "properties": {
@@ -120,7 +111,15 @@
                 "type": "string"
             },
             "metadata": {
-                "$ref": "#/definitions/metadata"
+                "type": "object",
+                "properties": {
+                    "tooltip": {
+                        "type": "string"
+                    },
+                    "template_variables": {
+                        "$ref": "#/definitions/template_variables"
+                    }
+                }
             }
         },
         "required": ["label", "hostname", "description", "transport", "scheduler", "work_dir", "shebang", "mpirun_command", "mpiprocs_per_machine", "prepend_text"],
@@ -140,7 +139,19 @@
                 "type": "string"
             },
             "metadata": {
-                "$ref": "#/definitions/metadata"
+                "type": "object",
+                "properties": {
+                    "tooltip": {
+                        "type": "string"
+                    },
+                    "ssh_auth": {
+                        "type": "string",
+                        "enum": ["password", "key", "2FA"]
+                    },
+                    "template_variables": {
+                        "$ref": "#/definitions/template_variables"
+                    }
+                }
             }
         },
         "required": ["safe_interval", "username"],
@@ -169,7 +180,19 @@
                 "type": "string"
             },
             "metadata": {
-                "$ref": "#/definitions/metadata"
+                "type": "object",
+                "properties": {
+                    "tooltip": {
+                        "type": "string"
+                    },
+                    "ssh_auth": {
+                        "type": "string",
+                        "enum": ["password", "key", "2FA"]
+                    },
+                    "template_variables": {
+                        "$ref": "#/definitions/template_variables"
+                    }
+                }
             }
         },
         "required": ["label", "description", "default_calc_job_plugin", "filepath_executable", "prepend_text", "append_text"],

--- a/merlin.psi.ch/cpu/codes/QE-7.0-exe-template.yml
+++ b/merlin.psi.ch/cpu/codes/QE-7.0-exe-template.yml
@@ -9,11 +9,12 @@ prepend_text: |
     module load qe/7.0
 append_text: ''
 metadata:
-    code_binary_name:
-        key_display: Code name
-        type: list
-        options:
-            - pw
-            - ph
-            - dos
-            - projwfc
+    template_variables:
+        code_binary_name:
+            key_display: Code name
+            type: list
+            options:
+                - pw
+                - ph
+                - dos
+                - projwfc

--- a/merlin.psi.ch/cpu/computer-configure.yml
+++ b/merlin.psi.ch/cpu/computer-configure.yml
@@ -7,7 +7,8 @@ metadata:
             Setup up the SSH connection.
         </p>
     ssh_auth: password
-    username:
-        description: The username to use for the SSH connection
-        type: text
-        key_display: SSH username
+    template_variables:
+        username:
+            description: The username to use for the SSH connection
+            type: text
+            key_display: SSH username

--- a/merlin.psi.ch/cpu/computer-setup.yml
+++ b/merlin.psi.ch/cpu/computer-setup.yml
@@ -22,25 +22,26 @@ metadata:
         <p>
             <a href="https://lsm-hpce.gitpages.psi.ch/merlin6/" target="_blank">Merlin</a> HPC at PSI.
         </p>
-    label:
-        default: merlin-cpu
-        description: A short name to identify the computer
-        type: text
-        key_display: Computer Label
-    slurm_partition:
-        default: general
-        description: The slurm partition to submit jobs to
-        type: list
-        options:
-            - general
-            - daily
-            - hourly
-        key_display: Slurm partition
-    multithreading:
-        default: nomultithread
-        description: The multithreading hint
-        type: list
-        options:
-            - nomultithread
-            - multithread
-        key_display: Multithreading hint
+    template_variables:
+        label:
+            default: merlin-cpu
+            description: A short name to identify the computer
+            type: text
+            key_display: Computer Label
+        slurm_partition:
+            default: general
+            description: The slurm partition to submit jobs to
+            type: list
+            options:
+                - general
+                - daily
+                - hourly
+            key_display: Slurm partition
+        multithreading:
+            default: nomultithread
+            description: The multithreading hint
+            type: list
+            options:
+                - nomultithread
+                - multithread
+            key_display: Multithreading hint

--- a/merlin.psi.ch/gpu/codes/QE-7.0-exe-template.yml
+++ b/merlin.psi.ch/gpu/codes/QE-7.0-exe-template.yml
@@ -9,11 +9,12 @@ prepend_text: |
     module load qe/7.0
 append_text: ''
 metadata:
-    code_binary_name:
-        key_display: Code name
-        type: list
-        options:
-            - pw
-            - ph
-            - dos
-            - projwfc
+    template_variables:
+        code_binary_name:
+            key_display: Code name
+            type: list
+            options:
+                - pw
+                - ph
+                - dos
+                - projwfc

--- a/merlin.psi.ch/gpu/computer-configure.yml
+++ b/merlin.psi.ch/gpu/computer-configure.yml
@@ -7,7 +7,8 @@ metadata:
             Setup up the SSH connection.
         </p>
     ssh_auth: password
-    username:
-        description: The username to use for the SSH connection
-        type: text
-        key_display: SSH username
+    template_variables:
+        username:
+            description: The username to use for the SSH connection
+            type: text
+            key_display: SSH username

--- a/merlin.psi.ch/gpu/computer-setup.yml
+++ b/merlin.psi.ch/gpu/computer-setup.yml
@@ -22,33 +22,34 @@ metadata:
         <p>
             <a href="https://lsm-hpce.gitpages.psi.ch/merlin6/" target="_blank">Merlin</a> HPC at PSI (gpu).
         </p>
-    label:
-        default: merlin-gpu
-        description: A short name to identify the computer
-        type: text
-        key_display: Computer Label
-    slurm_partition:
-        default: gpu
-        description: The slurm partition to submit jobs to
-        type: list
-        options:
-            - gpu
-            - gpu-short
-        key_display: Slurm partition
-    slurm_constraint:
-        default: gpumem_8gb
-        description: Specify the GPU by the amount of memory available in the GPU card itself.
-        type: list
-        options:
-            - gpumem_8gb
-            - gpumem_11gb
-            - gpumem_40gb
-        key_display: Slurm constraint
-    multithreading:
-        default: nomultithread
-        description: The multithreading hint
-        type: list
-        options:
-            - nomultithread
-            - multithread
-        key_display: Multithreading hint
+    template_variables:
+        label:
+            default: merlin-gpu
+            description: A short name to identify the computer
+            type: text
+            key_display: Computer Label
+        slurm_partition:
+            default: gpu
+            description: The slurm partition to submit jobs to
+            type: list
+            options:
+                - gpu
+                - gpu-short
+            key_display: Slurm partition
+        slurm_constraint:
+            default: gpumem_8gb
+            description: Specify the GPU by the amount of memory available in the GPU card itself.
+            type: list
+            options:
+                - gpumem_8gb
+                - gpumem_11gb
+                - gpumem_40gb
+            key_display: Slurm constraint
+        multithreading:
+            default: nomultithread
+            description: The multithreading hint
+            type: list
+            options:
+                - nomultithread
+                - multithread
+            key_display: Multithreading hint


### PR DESCRIPTION
@yakutovicha Please check the changes here, I am not so sure this is convenient for users who need to prepare the template, but this is more clear in the hierarchy to not mix the template variables with other properties such as `tooltip` and `ssh_auth`.