### PR TITLE
Add xspectra for merlin

### DIFF
--- a/merlin.psi.ch/cpu/codes/QuantumESPRESSO-7.0.yml
+++ b/merlin.psi.ch/cpu/codes/QuantumESPRESSO-7.0.yml
@@ -18,3 +18,4 @@ metadata:
                 - ph
                 - dos
                 - projwfc
+                - xspectra

--- a/merlin.psi.ch/gpu/codes/QuantumESPRESSO-7.0.yml
+++ b/merlin.psi.ch/gpu/codes/QuantumESPRESSO-7.0.yml
@@ -18,3 +18,4 @@ metadata:
                 - ph
                 - dos
                 - projwfc
+                - xspectra


### PR DESCRIPTION
For our XAS demo inside PSI, we need the xspectra code.